### PR TITLE
Taggle: Blocks in <a>-tags are not parsed

### DIFF
--- a/include/Taggle/impl/html/HTMLSchema.hpp
+++ b/include/Taggle/impl/html/HTMLSchema.hpp
@@ -50,7 +50,7 @@ private:
   {
 		elementType("<pcdata>", M_EMPTY, M_PCDATA, 0);
 		elementType("<root>", M_ROOT, M_EMPTY, 0);
-		elementType("a", M_PCDATA|M_NOLINK, M_INLINE, 0);
+		elementType("a", M_PCDATA|M_NOLINK|M_BLOCK, M_INLINE, 0);
 		elementType("abbr", M_PCDATA|M_INLINE, M_INLINE|M_NOLINK, F_RESTART);
 		elementType("acronym", M_PCDATA|M_INLINE, M_INLINE|M_NOLINK, F_RESTART);
 		elementType("address", M_PCDATA|M_INLINE|M_P, M_BLOCK, 0);


### PR DESCRIPTION
Taggle: Blocks in anchor-tags are not parsed

In the following HTML-text, the children of the anchor tag are not delivered by Taggle:

```
<a>
<div>test</div>
</a>
```

Taggle outputs this as `<a></a>`

Strictly not valid HTML, but frequently used in practice. Note that Taggle does not report any warnings / errors when parsing such input.

Suggested fix: allow blocks to be children of anchor-tags.
