### PR TITLE
Quick and dirty fix to allow the unit tests to pass

### DIFF
--- a/include/DOM/Simple/DOMImplementation.hpp
+++ b/include/DOM/Simple/DOMImplementation.hpp
@@ -68,7 +68,7 @@ class DOMImplementationImpl : public DOM::DOMImplementation_impl<stringT, string
                                                                          DOM::DocumentType_impl<stringT, string_adaptorT>* docType)
     {
       DocumentImpl<stringT, string_adaptorT>* doc = new DocumentImpl<stringT, string_adaptorT>(namespaceURI, qualifiedName, docType, this);
-
+      doc->addRef();
       if(!string_adaptorT::empty(qualifiedName))
         doc->appendChild(doc->createElementNS(namespaceURI, qualifiedName));
 


### PR DESCRIPTION
##### Warning: with C++11 you may need https://github.com/jezhiggins/arabica/pull/9 as well to compile Arabica
### Issue description

As is, the DocumentImpl object is deleted at the end of the call to appendChild (DOMImplementation.hpp:73) as its reference count follows the pattern:
- 0 (after line 70)
- 1 inside appendChild (the child calls addRef on it)
- 0 when we exit appendChild, which causes the object to be deleted.

This is a quick and dirty fix to allow the unit tests to pass. I am however unsure this should be used in production code as I have not encountered this problem otherwise. I would appreciate if someone could take a look and figure out if this is actually needed all the time or if we should maybe define another method for use in the unit tests.
