### PR TITLE
Fixes for the CDATA generation and W8.1 support in XSLT

### DIFF
--- a/include/SAX/wrappers/saxmsxml2.hpp
+++ b/include/SAX/wrappers/saxmsxml2.hpp
@@ -683,6 +683,10 @@ class msxml2_wrapper :
               HRESULT hr = attributes_->getIndexFromName(wUri.data(), static_cast<int>(wUri.length()),
                                                          wLocalName.data(), static_cast<int>(wLocalName.length()),
                                                          &index);
+              if (FAILED(hr))
+              {
+                index = -1;
+              }
               return index;
             } // getIndex
 
@@ -690,7 +694,11 @@ class msxml2_wrapper :
             {
               int index = -1;
               std::wstring wQName(string_adaptor::asStdWString(qName));
-              attributes_->getIndexFromQName(wQName.data(), static_cast<int>(wQName.length()), &index);
+              HRESULT hr = attributes_->getIndexFromQName(wQName.data(), static_cast<int>(wQName.length()), &index);
+              if (FAILED(hr))
+              {
+                index = -1;
+              }
 			  return index;
             } // getIndex
 

--- a/include/XSLT/impl/handler/xslt_constants.hpp
+++ b/include/XSLT/impl/handler/xslt_constants.hpp
@@ -131,7 +131,7 @@ STYLESHEETCONSTANT(Version, "1.0");
 STYLESHEETCONSTANT(Vendor, "Jez Higgins, JezUK Ltd");
 STYLESHEETCONSTANT(VendorUrl, "http://www.jezuk.co.uk/arabica/");
 
-STYLESHEETCONSTANT(CDATAStart, "<[CDATA[");
+STYLESHEETCONSTANT(CDATAStart, "<![CDATA[");
 STYLESHEETCONSTANT(CDATAEnd, "]]>");
 STYLESHEETCONSTANT(CommentStart, "<!--");
 STYLESHEETCONSTANT(CommentEnd, "-->");


### PR DESCRIPTION
The Windows 8.1 changed the behavior of the getIndexFromName. The function updates the index to 0 even if the function call fails.

The XSLT transformation is not working properly with the CDATA because the constant was not correct.
