### PR TITLE
Fix MSXML2 include errors in application build

### DIFF
--- a/include/SAX/wrappers/saxmsxml2.hpp
+++ b/include/SAX/wrappers/saxmsxml2.hpp
@@ -15,6 +15,8 @@
 #include <Arabica/getparam.hpp>
 
 // Include the MSXML definitions.
+#include <windows.h>
+#include <objbase.h>
 #include <msxml2.h>
 
 //


### PR DESCRIPTION
```
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(48): error C2146: syntax error: missing ';' before identifier 'IXMLDOMImplementation'
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(55): error C2146: syntax error: missing ';' before identifier 'IXMLDOMNode'
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(62): error C2146: syntax error: missing ';' before identifier 'IXMLDOMDocumentFragment'
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(69): error C2146: syntax error: missing ';' before identifier 'IXMLDOMDocument'
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(76): error C2146: syntax error: missing ';' before identifier 'IXMLDOMDocument2'
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(83): error C2146: syntax error: missing ';' before identifier 'IXMLDOMDocument3'
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(90): error C2146: syntax error: missing ';' before identifier 'IXMLDOMNodeList'
...
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml.h(614): error C2371: 'IXMLDOMNode': redefinition; different basic types
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(55): note: see declaration of 'IXMLDOMNode'
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml.h(1159): error C2371: 'IXMLDOMDocumentFragment': redefinition; different basic types
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(62): note: see declaration of 'IXMLDOMDocumentFragment'
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml.h(1586): error C2371: 'IXMLDOMDocument': redefinition; different basic types
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(69): note: see declaration of 'IXMLDOMDocument'
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml.h(2404): error C2371: 'IXMLDOMNodeList': redefinition; different basic types
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\msxml2.h(90): note: see declaration of 'IXMLDOMNodeList'
...
```


I got these error messages in my application (CMake + Visual Studio 2026) because `<windows.h>` and `<objbase.h>` need to be included before `<msxml2.h>`.

These errors do not occur when building the library. It only occur when the application includes the header files directly.