### PR TITLE
first_argument_type was removed with C++20

### DIFF
--- a/include/XPath/impl/xpath_object.hpp
+++ b/include/XPath/impl/xpath_object.hpp
@@ -506,10 +506,19 @@ template<typename string_type, typename string_adaptor> struct value_of_node<dou
   double operator()(const DOM::Node<string_type, string_adaptor>& node) { return nodeNumberValue<string_type, string_adaptor>(node); }
 }; 
 
+template<typename Op>
+struct opTraits;
+
+template<template<typename> class Comp, typename T>
+struct opTraits<Comp<T>>
+{
+  typedef T value_type;
+};
+
 template<class Op, class string_type, class string_adaptor>
 class compareNodeWith
 {
-  typedef typename Op::first_argument_type T;
+  typedef typename opTraits<Op>::value_type T;
 
 
 public:


### PR DESCRIPTION
The member type `first_argument_type` was removed in C++20 from `std::equal_to`, `std::not_equal_to`, `std::less`, `std::less_equal`, `std::greater`, and `std::greater_equal`.

The code previously relied on this typedef to obtain the argument type of the comparison functors. With its removal, there is no simple standard mechanism to extract the argument type generically.

In our use case, the argument type corresponds directly to the template parameter of the comparison functor. We therefore deduce this type and use it as the value type for `compareNodeWith`.